### PR TITLE
feat: Update /parse_pdf endpoint to support parsing DOCX files

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -1,31 +1,15 @@
 from io import BytesIO
 from docx import Document
-from reportlab.lib.pagesizes import letter
-from reportlab.pdfgen import canvas
 
-def convert_docx_to_pdf_in_memory(docx_buffer: BytesIO):
+def convert_docx_to_string(docx_buffer: BytesIO) -> str:
     # Read the DOCX file from the in-memory content
     document = Document(docx_buffer)
     
-    # Create an in-memory bytes buffer for the PDF
-    pdf_buffer = BytesIO()
-    pdf = canvas.Canvas(pdf_buffer, pagesize=letter)
+    # Create an empty string to store the content
+    content = ""
     
-    width, height = letter
-    # pdf.setFont("Helvetica", 12)
-    y_position = height - 40  # Start a bit below the top of the page
-
     for paragraph in document.paragraphs:
         text = paragraph.text
-        pdf.drawString(40, y_position, text)
-        y_position -= 15  # Move down the page for the next line
+        content += text + "\n"  # Add the paragraph text to the content string
 
-        if y_position < 40:  # If at the bottom of the page, create a new page
-            pdf.showPage()
-            y_position = height - 40
-
-    pdf.save()
-    
-    # Get the PDF content from the buffer
-    pdf_buffer.seek(0)
-    return pdf_buffer
+    return content


### PR DESCRIPTION
This commit modifies the /parse_pdf endpoint to handle both PDF and DOCX files for parsing. It introduces a new function `convert_docx_to_string` in the `converter.py` file, which takes a DOCX file buffer as input and returns the text content of the file. The function uses the `python-docx` library to read the DOCX file and extracts the text content. This change allows users to upload DOCX files and parse them along with PDF files in the application.

Closes #10